### PR TITLE
feat: add green book sections to homepage

### DIFF
--- a/server/server/captcha.js
+++ b/server/server/captcha.js
@@ -28,14 +28,13 @@ router.get('/captcha', (req,res)=>{
 router.get('/slider/new', (req,res)=> res.status(200).json({ id: randomUUID(), width:280, height:160, notchX:80, bg:'' }));
 
 // 校验图片验证码（成功后失效）
-export function verifyCaptchaOrThrow(req, purpose='login'){
-  const { captchaId, captcha } = req.body || {};
-  const rec = store.get(captchaId);
+export function verifyCaptchaOrThrow(purpose, id, answer){
+  const rec = store.get(id);
   if (!rec) throw new Error('验证码已过期，请重试');
-  if (Date.now() > rec.exp) { store.delete(captchaId); throw new Error('验证码已过期，请重试'); }
+  if (Date.now() > rec.exp) { store.delete(id); throw new Error('验证码已过期，请重试'); }
   if (purpose && rec.purpose && purpose !== rec.purpose) throw new Error('验证码无效，请刷新');
-  if (norm(captcha) !== rec.ans) throw new Error('验证码错误');
-  store.delete(captchaId);
+  if (norm(answer) !== rec.ans) throw new Error('验证码错误');
+  store.delete(id);
   return true;
 }
 

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -1,6 +1,12 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
-export type User = { id:string; email:string; name?:string|null; avatar_url?:string|null }
+export type User = {
+  id: string;
+  email: string;
+  name?: string | null;
+  avatar_url?: string | null;
+  email_verified?: boolean;
+}
 type Ctx = {
   user: User | null;
   loading: boolean;

--- a/web/src/components/GreenBookGrid.tsx
+++ b/web/src/components/GreenBookGrid.tsx
@@ -1,0 +1,26 @@
+const cards = [
+  { img:'/img/hero-savanna.jpg', title:'野生动物探险', desc:'追随迁徙之路，感受草原脉动。' },
+  { img:'/img/hero-coast2.jpg', title:'海岸线之旅', desc:'湛蓝海水与白沙滩的浪漫邂逅。' },
+  { img:'/img/hero-dunes.jpg', title:'沙漠星空营地', desc:'在沙海与星光下，寻觅静谧。' },
+];
+
+export default function GreenBookGrid(){
+  return (
+    <section className="container section">
+      <h2 className="h2 text-center">GREENBOOK</h2>
+      <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        {cards.map(c => (
+          <div key={c.title} className="rounded-xl overflow-hidden bg-red-600 text-white flex flex-col">
+            <img src={c.img} alt={c.title} className="h-40 w-full object-cover"/>
+            <div className="p-4 flex flex-col flex-1">
+              <h3 className="text-lg font-semibold mb-2">{c.title}</h3>
+              <p className="text-sm flex-1">{c.desc}</p>
+              <a href="#" className="btn secondary mt-4 self-start">立即预订</a>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/web/src/components/GreenBookIntro.tsx
+++ b/web/src/components/GreenBookIntro.tsx
@@ -1,0 +1,17 @@
+import dunes from '../assets/hero-dunes.jpg';
+
+export default function GreenBookIntro(){
+  return (
+    <section className="container section">
+      <h2 className="h2 text-center">GREEN BOOK</h2>
+      <div className="mt-8 flex flex-col md:flex-row items-center gap-8">
+        <img src={dunes} alt="Green Book" className="rounded-xl w-full md:w-1/2"/>
+        <div className="prose max-w-prose">
+          <h3 className="h3">绿旅指南</h3>
+          <p>探索未知的旅程，体验非洲的独特魅力。我们精选本地风情与自然奇观，为你呈现最真实的非洲。</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/web/src/env.d.ts
+++ b/web/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/web/src/modules/App.tsx
+++ b/web/src/modules/App.tsx
@@ -4,7 +4,7 @@ type Role = 'user'|'assistant'|'system';
 interface ChatMessage { role: Role; content: string; }
 
 function looksLikeJSON(s:string){ const t=s.trim(); return t.startsWith('{')||t.startsWith('[');}
-function pickText(obj:any){
+function pickText(obj:any): string {
   if(!obj) return '';
   if(typeof obj.text==='string') return obj.text;
   if(typeof obj.content==='string') return obj.content;
@@ -44,7 +44,7 @@ export default function ChatModule(){
     const text = input.trim();
     if(!text) return;
     setInput('');
-    const newHistory = [...history, {role:'user', content:text}];
+    const newHistory: ChatMessage[] = [...history, { role: 'user', content: text }];
     setHistory(newHistory);
     setLoading(true);
     try{

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,52 +1,17 @@
 import Hero from "../components/Hero";
-import DestinationMosaic from "../components/DestinationMosaic";
-import useReveal from "../hooks/useReveal";
+import GreenBookIntro from "../components/GreenBookIntro";
+import GreenBookGrid from "../components/GreenBookGrid";
 
 export default function Home(){
-  const r1 = useReveal<HTMLDivElement>(), r2 = useReveal<HTMLDivElement>(), r3 = useReveal<HTMLDivElement>();
   return (
     <>
-      <div className="container section"><Hero/></div>
-
-      <div className="container section reveal" ref={r1}>
-        <div className="kicker">Our Promise</div>
-        <h2 className="h2">我们只是中介 · 让旅行回归简单</h2>
-        <div className="grid3">
-          {[
-            {img:'/img/hero-savanna.jpg', title:'透明撮合', desc:'只撮合本地持牌商家；价格清晰，统一售后。'},
-            {img:'/img/hero-coast2.jpg',  title:'一站代办', desc:'门票/预约/接驳按路线一次性代买，省心省时。'},
-            {img:'/img/hero-dunes.jpg',   title:'AI 助理', desc:'用 AI 先生成可执行路线，再按需微调与下单。'},
-          ].map(c=>(
-            <div className="card" key={c.title}>
-              <div className="img" style={{backgroundImage:`url(${c.img})`}}/>
-              <div className="b">
-                <div className="h3">{c.title}</div>
-                <div className="muted">{c.desc}</div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <DestinationMosaic/>
-
-      <div className="container section reveal" ref={r2}>
-        <div className="marquee">
-          <span>Desert · Savanna · Coast · Volcano · Rift Valley · Coral · Spice · Culture · Wildlife · Diving · City Break · Self-drive · Hot Air Balloon · </span>
-          <span>Desert · Savanna · Coast · Volcano · Rift Valley · Coral · Spice · Culture · Wildlife · Diving · City Break · Self-drive · Hot Air Balloon · </span>
-        </div>
-      </div>
-
-      <div className="container section reveal" ref={r3}>
-        <div className="kicker">Get Started</div>
-        <h2 className="h2">从一条草图开始 · AI 为你生成完整行程</h2>
-        <div className="card" style={{padding:18,display:'flex',alignItems:'center',gap:16}}>
-          <div className="badge">示例</div>
-          <div className="muted" style={{flex:1}}>“7 天肯尼亚+坦桑尼亚，预算中等，想看动物迁徙和热气球”</div>
-          <a href="/planner" className="btn">打开 AI 行程助手</a>
-          <a href="/products" className="btn secondary">看看打包产品</a>
-        </div>
-      </div>
+      <Hero/>
+      <GreenBookIntro/>
+      <GreenBookGrid/>
+      <section className="container section text-center">
+        <h2 className="h2">OUR DESTINATIONS</h2>
+      </section>
     </>
   );
 }
+

--- a/web/src/pages/Planner.tsx
+++ b/web/src/pages/Planner.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
 
 const interests = [
   {key:'wildlife', label:'野生动物'},
@@ -48,7 +50,7 @@ export default function Planner(){
     const j = await r.json();
     setBusy(false);
     if (!r.ok) { setResult(`生成失败：${j?.error||r.status}`); return; }
-    setResult(j?.content || j?.answer || '无内容');
+    setResult(j?.text || j?.content || j?.answer || '无内容');
   }
 
   return (
@@ -106,8 +108,11 @@ export default function Planner(){
       </div>
 
       {result && (
-        <div className="card" style={{padding:16, marginTop:16}}>
-          <div className="markdown" dangerouslySetInnerHTML={{__html: window.DOMPurify?.sanitize(window.marked?.parse(result)||result) || result}} />
+        <div className="card" style={{ padding: 16, marginTop: 16 }}>
+          <div
+            className="markdown"
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked.parse(result) as string) }}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add Green Book intro and card grid components
- wire new sections into home page and add Vite env types
- fix captcha verification, handle AI planner responses, and show hero banner full width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `DOUBAO_API_KEY=dummy DOUBAO_BASE_URL=http://example.com npm start`


------
https://chatgpt.com/codex/tasks/task_e_68a1f49ede7c832081d1f6ccebb7ac6d